### PR TITLE
Remove trailing tab character 

### DIFF
--- a/resources/ignore-urls.txt
+++ b/resources/ignore-urls.txt
@@ -3,4 +3,4 @@ https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 https://www.contributor-covenant.org/faq][FAQ].
 https://www.contributor-covenant.org/translations][translations].
 https://github.com/jhudsl/OTTR_Template/issues/new/choose)!
-https://github.com/<your-username>/github-actions-workshop	
+https://github.com/<your-username>/github-actions-workshop


### PR DESCRIPTION
This PR removes an invisible trailing `\t` in the `ignore-urls.txt` file. This was the culprit in the unexpected url check failure reported in ottrproject/OTTR_Template#3.